### PR TITLE
Changes to make the device configurations here work for master branch

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -33,7 +33,6 @@ CONFIG_DRIVER_NL80211 := y
 CONFIG_DRIVER_WEXT :=y
 
 
-BOARD_KERNEL_CMDLINE := k3v2mem hisi_dma_print=0 vmalloc=484M no_irq_affinity loglevel=7 androidboot.hardware=hikey selinux=0
 BOARD_KERNEL_BASE := 0x07400000
 BOARD_DTB_ADDR := 0x09e00000
 BOARD_RAMDISK_OFFSET := 0x07c00000
@@ -55,6 +54,7 @@ KERNEL_CONFIG = arch/arm64/configs/defconfig android/configs/android-base.cfg  a
 TARGET_KERNEL_SOURCE ?= kernel/linaro/hisilicon
 DEVICE_TREES := hi6220-hikey:hi6220-hikey.dtb
 BUILD_KERNEL_MODULES ?= true
+GATOR_DAEMON_PATH := $(TARGET_KERNEL_SOURCE)
 
 TARGET_NO_BOOTLOADER := true
 TARGET_NO_KERNEL := false
@@ -73,3 +73,4 @@ BOARD_CACHEIMAGE_FILE_SYSTEM_TYPE := ext4
 BOARD_FLASH_BLOCK_SIZE := 131072
 TARGET_USE_PAN_DISPLAY := true
 
+BOARD_SEPOLICY_DIRS += device/linaro/build/sepolicy

--- a/cmdline
+++ b/cmdline
@@ -1,1 +1,1 @@
-k3v2mem hisi_dma_print=0 vmalloc=484M no_irq_affinity loglevel=7 androidboot.console=ttyAMA0 androidboot.hardware=hikey selinux=0 root=/dev/mmcblk0p7 firmware_class.path=/system/etc/firmware
+k3v2mem hisi_dma_print=0 vmalloc=484M no_irq_affinity loglevel=7 androidboot.console=ttyAMA0 androidboot.hardware=hikey androidboot.selinux=permissive root=/dev/mmcblk0p7 firmware_class.path=/system/etc/firmware

--- a/device.mk
+++ b/device.mk
@@ -69,6 +69,7 @@ PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.zygote=zygote64_32
 PRODUCT_PROPERTY_OVERRIDES += \
          debug.sf.no_hw_vsync=1
 
+
 PRODUCT_COPY_FILES += system/core/rootdir/init.zygote64_32.rc:root/init.zygote64_32.rc
 
 #enable consle even built in user mode
@@ -104,7 +105,8 @@ PRODUCT_COPY_FILES += device/linaro/build/media_codecs.xml:system/etc/media_code
 $(call inherit-product-if-exists, device/linaro/build/extra-and-tests.mk)
 
 # Include BT modules
-$(call inherit-product-if-exists, hardware/ti/wpan/ti-wpan-products.mk)
+#$(call inherit-product-if-exists, hardware/ti/wpan/ti-wpan-products.mk)
+PRODUCT_DEFAULT_PROPERTY_OVERRIDES += config.disable_bluetooth=true
 
 # Include Android userspace tests
 $(call inherit-product-if-exists, external/linaro-android-userspace-test/product.mk)

--- a/dhcpcd/Android.mk
+++ b/dhcpcd/Android.mk
@@ -1,3 +1,4 @@
+ifeq (hikey, $(TARGET_PRODUCT))
 LOCAL_PATH := $(call my-dir)
 include $(CLEAR_VARS)
 LOCAL_MODULE := dhcpcd.conf
@@ -5,3 +6,4 @@ LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_OUT_ETC)/dhcpcd
 LOCAL_SRC_FILES := android_dhcpcd.conf
 include $(BUILD_PREBUILT)
+endif

--- a/init.hikey.rc
+++ b/init.hikey.rc
@@ -108,8 +108,6 @@ on post-fs
 
     chmod 0666 /dev/ump
     chmod 0666 /dev/ion
-    chmod 0666 /dev/mali
-    chown system.graphics /dev/mali
     chmod 0666 /dev/graphics/fb0
 
 on boot

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -1,2 +1,0 @@
-/dev/mali0              u:object_r:gpu_device:s0
-/dev/ump              u:object_r:gpu_device:s0

--- a/ueventd.hikey.rc
+++ b/ueventd.hikey.rc
@@ -1,1 +1,2 @@
 /dev/hci_tty     0666 root root
+/dev/mali       0666 system graphics


### PR DESCRIPTION
1. remove selinux=0 to enable selinux in kernel and add
   androidboot.selinux=permissive  to bootarg to make it run in permissive mode
2. add GATOR_DAEMON_PATH variable so that we can build with other kernels locally
   need a patch in the kernel side as well
3. disabled bluetooth feature to avoid the bluetooth compiling problem
4. add condition check for dhcpcd module to make it work with other builds locally
5. move permission and owner setting for /dev/mali from init.hikey.rc to ueventd.hikey.rc
6. add BOARD_SEPOLICY_DIRS to use the sepolicies defined in linaro build git tree

Signed-off-by: Yongqin Liu yongqin.liu@linaro.org
