### PR TITLE
enable selinux on Hikey Master

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -74,3 +74,4 @@ BOARD_FLASH_BLOCK_SIZE := 131072
 TARGET_USE_PAN_DISPLAY := true
 
 BOARD_SEPOLICY_DIRS += device/linaro/build/sepolicy
+BOARD_SEPOLICY_DIRS += device/linaro/hikey/sepolicy

--- a/cmdline
+++ b/cmdline
@@ -1,1 +1,1 @@
-k3v2mem hisi_dma_print=0 vmalloc=484M no_irq_affinity loglevel=7 androidboot.console=ttyAMA0 androidboot.hardware=hikey androidboot.selinux=permissive root=/dev/mmcblk0p7 firmware_class.path=/system/etc/firmware
+k3v2mem hisi_dma_print=0 vmalloc=484M no_irq_affinity loglevel=7 androidboot.console=ttyAMA0 androidboot.hardware=hikey root=/dev/mmcblk0p7 firmware_class.path=/system/etc/firmware

--- a/sepolicy/file.te
+++ b/sepolicy/file.te
@@ -1,0 +1,1 @@
+type configfs, fs_type;

--- a/sepolicy/genfs_contexts
+++ b/sepolicy/genfs_contexts
@@ -1,0 +1,1 @@
+genfscon configfs / u:object_r:configfs:s0

--- a/sepolicy/init.te
+++ b/sepolicy/init.te
@@ -1,0 +1,3 @@
+allow init configfs:dir { write add_name create };
+allow init configfs:file { write };
+allow init configfs:lnk_file { create };

--- a/sepolicy/kernel.te
+++ b/sepolicy/kernel.te
@@ -1,0 +1,8 @@
+# for krfcommd command
+allow kernel self:capability net_bind_service;
+
+# for kdevtmpfs command
+allow kernel self:capability mknod;
+allow kernel device:dir { write add_name };
+allow kernel device:chr_file { create setattr getattr};
+


### PR DESCRIPTION
This change depends on the change here,
http://review.android.git.linaro.org/#/c/15852/
After that and this change merged, we can enabled selinux for Hikey Master build.

The change here is mainly settings on configfs, which Hikey used to enabled the adb over usb

Signed-off-by: Yongqin Liu yongqin.liu@linaro.org
