### PR TITLE
enable selinux for lollipop

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -55,6 +55,7 @@ KERNEL_CONFIG = arch/arm64/configs/defconfig android/configs/android-base.cfg  a
 TARGET_KERNEL_SOURCE ?= kernel/linaro/hisilicon
 DEVICE_TREES := hi6220-hikey:hi6220-hikey.dtb
 BUILD_KERNEL_MODULES ?= true
+GATOR_DAEMON_PATH := $(TARGET_KERNEL_SOURCE)
 
 TARGET_NO_BOOTLOADER := true
 TARGET_NO_KERNEL := false
@@ -73,3 +74,21 @@ BOARD_CACHEIMAGE_FILE_SYSTEM_TYPE := ext4
 BOARD_FLASH_BLOCK_SIZE := 131072
 TARGET_USE_PAN_DISPLAY := true
 
+BOARD_SEPOLICY_DIRS += device/linaro/build/sepolicy
+BOARD_SEPOLICY_UNION += \
+        file_contexts \
+        gatord.te  \
+        init.te  \
+        kernel.te  \
+        logd.te  \
+        mediaserver.te  \
+        netd.te  \
+        shell.te  \
+        surfaceflinger.te
+
+BOARD_SEPOLICY_DIRS += device/linaro/hikey/sepolicy
+BOARD_SEPOLICY_UNION += \
+        file.te \
+        genfs_contexts \
+        init.te \
+        kernel.te

--- a/cmdline
+++ b/cmdline
@@ -1,1 +1,1 @@
-k3v2mem hisi_dma_print=0 vmalloc=484M no_irq_affinity loglevel=7 androidboot.console=ttyAMA0 androidboot.hardware=hikey selinux=0 root=/dev/mmcblk0p7 firmware_class.path=/system/etc/firmware
+k3v2mem hisi_dma_print=0 vmalloc=484M no_irq_affinity loglevel=7 androidboot.console=ttyAMA0 androidboot.hardware=hikey root=/dev/mmcblk0p7 firmware_class.path=/system/etc/firmware

--- a/sepolicy/file.te
+++ b/sepolicy/file.te
@@ -1,0 +1,1 @@
+type configfs, fs_type;

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -1,2 +1,0 @@
-/dev/mali0              u:object_r:gpu_device:s0
-/dev/ump              u:object_r:gpu_device:s0

--- a/sepolicy/genfs_contexts
+++ b/sepolicy/genfs_contexts
@@ -1,0 +1,1 @@
+genfscon configfs / u:object_r:configfs:s0

--- a/sepolicy/init.te
+++ b/sepolicy/init.te
@@ -1,0 +1,3 @@
+allow init configfs:dir { write add_name create };
+allow init configfs:file { write };
+allow init configfs:lnk_file { create };

--- a/sepolicy/kernel.te
+++ b/sepolicy/kernel.te
@@ -1,0 +1,8 @@
+# for krfcommd command
+allow kernel self:capability net_bind_service;
+
+# for kdevtmpfs command
+allow kernel self:capability mknod;
+allow kernel device:dir { write add_name };
+allow kernel device:chr_file { create setattr getattr};
+


### PR DESCRIPTION
mainly sepolicy settings on configfs and kernel about kdevtmpfs

Signed-off-by: Yongqin Liu yongqin.liu@linaro.org
