### PR TITLE
Add phony bootimage.

### DIFF
--- a/boot_fat.mk
+++ b/boot_fat.mk
@@ -1,3 +1,4 @@
+.PHONY: bootimage all_dtbs
 
 REALTOP=$(realpath $(TOP))
 FASTBOOT_EFI_BUILD_NUMBER := `wget -q --no-check-certificate -O - https://ci.linaro.org/job/96boards-hikey-uefi/lastSuccessfulBuild/buildNumber`


### PR DESCRIPTION
This goes in conjunction with http://android-review.linaro.org/16140 to get droidcore to build again.

Signed-off-by: Daniel Díaz daniel.diaz@linaro.org
