### PR TITLE
init.hikey.rc: move sdcard symbol link creation into post-fs

### DIFF
--- a/init.hikey.rc
+++ b/init.hikey.rc
@@ -8,10 +8,6 @@ on init
     # disable transparent huge pages
     write /sys/kernel/mm/transparent_hugepage/enabled "never"
 
-    # See storage config details at http://source.android.com/tech/storage/
-    symlink /sdcard /mnt/sdcard
-    symlink /sdcard /storage/sdcard0
-
 
     # Disabled virtual memory randomization
     # (if randomization is enabled the AEM-JIT will have a lower cache hit rate)
@@ -55,6 +51,13 @@ on post-fs-data
     restorecon_recursive /data/local/tmp/lava
 
 on post-fs
+
+    # For legacy support
+    # See storage config details at http://source.android.com/tech/storage/
+    # since /storage is mounted on post-fs in init.rc
+    symlink /sdcard /mnt/sdcard
+    symlink /sdcard /storage/sdcard0
+
     # insert WiFi Modules
        insmod /system/modules/rfkill.ko
        insmod /system/modules/wifi/compat.ko


### PR DESCRIPTION
otherwise the /storage/sdcard0 symbol link will not be created
since the /storage is mounted in the post-fs section in init.rc

Signed-off-by: Yongqin Liu yongqin.liu@linaro.org
