### PR TITLE
Changes to move sepolicy rules only in this hikey device configuration repository

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -75,6 +75,9 @@ TARGET_USE_PAN_DISPLAY := true
 
 BOARD_SEPOLICY_DIRS += device/linaro/hikey/sepolicy
 BOARD_SEPOLICY_UNION += \
+        debuggerd.te \
+        dex2oat.te \
+        drmserver.te \
         file_contexts \
         file.te \
         genfs_contexts \

--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -73,26 +73,16 @@ BOARD_CACHEIMAGE_FILE_SYSTEM_TYPE := ext4
 BOARD_FLASH_BLOCK_SIZE := 131072
 TARGET_USE_PAN_DISPLAY := true
 
-BOARD_SEPOLICY_DIRS += device/linaro/build/sepolicy
-BOARD_SEPOLICY_UNION += \
-        file_contexts \
-        gatord.te  \
-        hci_attach.te \
-        healthd.te \
-        init.te  \
-        kernel.te  \
-        linaro.te \
-        logd.te  \
-        mediaserver.te  \
-        netd.te  \
-        shell.te  \
-        surfaceflinger.te \
-        toolbox.te \
-        zygote.te
-
 BOARD_SEPOLICY_DIRS += device/linaro/hikey/sepolicy
 BOARD_SEPOLICY_UNION += \
+        file_contexts \
         file.te \
         genfs_contexts \
+        hci_attach.te \
+        healthd.te \
         init.te \
-        kernel.te
+        kernel.te  \
+        netd.te  \
+        shell.te  \
+        toolbox.te \
+        zygote.te

--- a/sepolicy/debuggerd.te
+++ b/sepolicy/debuggerd.te
@@ -1,0 +1,2 @@
+# For CONFIG_MODULES
+allow debuggerd kernel:system module_request;

--- a/sepolicy/dex2oat.te
+++ b/sepolicy/dex2oat.te
@@ -1,0 +1,2 @@
+# For CONFIG_MODULES
+allow dex2oat kernel:system module_request;

--- a/sepolicy/drmserver.te
+++ b/sepolicy/drmserver.te
@@ -1,0 +1,2 @@
+# For CONFIG_MODULES
+allow drmserver kernel:system module_request;

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -1,0 +1,10 @@
+/data/linaro-android-kernel-test(/.*)?	u:object_r:shell_data_file:s0
+/data/linaro-android-userspace-test(/.*)?	u:object_r:shell_data_file:s0
+/data/nativebenchmark(/.*)?	u:object_r:shell_data_file:s0
+/dev/ttyAMA0   u:object_r:console_device:s0
+/dev/ttyAMA3   u:object_r:console_device:s0
+/dev/mali              u:object_r:gpu_device:s0
+/dev/dri/card0         u:object_r:gpu_device:s0
+/dev/hci_tty           u:object_r:hci_attach_dev:s0
+/dev/ttyAMA1           u:object_r:hci_attach_dev:s0
+/system/bin/uim    u:object_r:hci_attach_exec:s0

--- a/sepolicy/hci_attach.te
+++ b/sepolicy/hci_attach.te
@@ -1,0 +1,1 @@
+allow hci_attach self:capability dac_override;

--- a/sepolicy/healthd.te
+++ b/sepolicy/healthd.te
@@ -1,0 +1,1 @@
+allow healthd self:capability { dac_override dac_read_search sys_nice };

--- a/sepolicy/init.te
+++ b/sepolicy/init.te
@@ -1,3 +1,12 @@
 allow init configfs:dir { write add_name create };
 allow init configfs:file { write };
 allow init configfs:lnk_file { create };
+
+allow init tmpfs:lnk_file create_file_perms;
+allow init cache_file:dir mounton;
+allow init storage_file:dir mounton;
+
+allow init self:capability { sys_module sys_pacct };
+allow init bootchart_data_file:file { append };
+
+allow init shell_data_file:lnk_file { getattr };

--- a/sepolicy/kernel.te
+++ b/sepolicy/kernel.te
@@ -4,3 +4,6 @@ allow kernel device:dir { write add_name rmdir remove_name rmdir remove_name};
 allow kernel device:chr_file { create setattr getattr unlink };
 
 allow kernel shell_data_file:file { read write };
+
+# For CONFIG_MODULES
+allow kernel self:system { module_request };

--- a/sepolicy/kernel.te
+++ b/sepolicy/kernel.te
@@ -1,8 +1,6 @@
-# for krfcommd command
-allow kernel self:capability net_bind_service;
-
 # for kdevtmpfs command
 allow kernel self:capability mknod;
 allow kernel device:dir { write add_name rmdir remove_name rmdir remove_name};
 allow kernel device:chr_file { create setattr getattr unlink };
-allow kernel self:system module_request;
+
+allow kernel shell_data_file:file { read write };

--- a/sepolicy/netd.te
+++ b/sepolicy/netd.te
@@ -1,0 +1,1 @@
+dontaudit netd self:capability sys_module;

--- a/sepolicy/netd.te
+++ b/sepolicy/netd.te
@@ -1,1 +1,4 @@
 dontaudit netd self:capability sys_module;
+
+# for CONFIG_MODULES
+allow netd kernel:system module_request;

--- a/sepolicy/toolbox.te
+++ b/sepolicy/toolbox.te
@@ -1,0 +1,1 @@
+allow toolbox self:capability { dac_override dac_read_search sys_nice };

--- a/sepolicy/zygote.te
+++ b/sepolicy/zygote.te
@@ -1,0 +1,1 @@
+allow zygote self:capability sys_nice;

--- a/sepolicy/zygote.te
+++ b/sepolicy/zygote.te
@@ -1,1 +1,4 @@
 allow zygote self:capability sys_nice;
+
+# For CONFIG_MODULES
+allow zygote kernel:system module_request;


### PR DESCRIPTION
There is also a change for CONFIG_MODULES config which is enabled with the 3.18 kernel.
We can revert it when we have CONFIG_MODULES disabled with 4.1 kernel
