### PR TITLE
Revert "add sepolicy rules for CONFIG_MODULES"

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -75,9 +75,6 @@ TARGET_USE_PAN_DISPLAY := true
 
 BOARD_SEPOLICY_DIRS += device/linaro/hikey/sepolicy
 BOARD_SEPOLICY_UNION += \
-        debuggerd.te \
-        dex2oat.te \
-        drmserver.te \
         file_contexts \
         file.te \
         genfs_contexts \

--- a/sepolicy/debuggerd.te
+++ b/sepolicy/debuggerd.te
@@ -1,2 +1,0 @@
-# For CONFIG_MODULES
-allow debuggerd kernel:system module_request;

--- a/sepolicy/dex2oat.te
+++ b/sepolicy/dex2oat.te
@@ -1,2 +1,0 @@
-# For CONFIG_MODULES
-allow dex2oat kernel:system module_request;

--- a/sepolicy/drmserver.te
+++ b/sepolicy/drmserver.te
@@ -1,2 +1,0 @@
-# For CONFIG_MODULES
-allow drmserver kernel:system module_request;

--- a/sepolicy/kernel.te
+++ b/sepolicy/kernel.te
@@ -4,6 +4,3 @@ allow kernel device:dir { write add_name rmdir remove_name rmdir remove_name};
 allow kernel device:chr_file { create setattr getattr unlink };
 
 allow kernel shell_data_file:file { read write };
-
-# For CONFIG_MODULES
-allow kernel self:system { module_request };

--- a/sepolicy/netd.te
+++ b/sepolicy/netd.te
@@ -1,4 +1,1 @@
 dontaudit netd self:capability sys_module;
-
-# for CONFIG_MODULES
-allow netd kernel:system module_request;

--- a/sepolicy/zygote.te
+++ b/sepolicy/zygote.te
@@ -1,4 +1,1 @@
 allow zygote self:capability sys_nice;
-
-# For CONFIG_MODULES
-allow zygote kernel:system module_request;


### PR DESCRIPTION
CONFIG_MODULES is disabled on Kernel 4.1 version now
This reverts commit a20c58bd065699075c588e3a587570899f51dc48.
