### PR TITLE
Revert "grub: Add multiple boot option with different display resolut

### DIFF
--- a/grub.cfg
+++ b/grub.cfg
@@ -1,22 +1,6 @@
 set default="0"
 set timeout=1
 
-menuentry 'AOSP@720P' {
-    search.fs_label boot root
-    set root=($root)
-    linux /Image console=ttyAMA3,115200 androidboot.console=ttyAMA3 androidboot.hardware=hikey firmware_class.path=/system/etc/firmware efi=noruntime video=HDMI-A-1:1280x720@60
-    initrd /ramdisk.img
-    devicetree /hi6220-hikey.dtb
-}
-
-menuentry 'AOSP@SVGA' {
-    search.fs_label boot root
-    set root=($root)
-    linux /Image console=ttyAMA3,115200 androidboot.console=ttyAMA3 androidboot.hardware=hikey firmware_class.path=/system/etc/firmware efi=noruntime video=HDMI-A-1:800x600@60
-    initrd /ramdisk.img
-    devicetree /hi6220-hikey.dtb
-}
-
 menuentry 'AOSP' {
     search.fs_label boot root
     set root=($root)


### PR DESCRIPTION
Revert this default resolution is 720p, because 1080p color display issue is
solved

This reverts commit 72e035666f273c98354a42db685bdaa8e3c78267.

Conflicts:
    grub.cfg
