### PR TITLE
update to use the heap configurations for 1024MB devices

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -15,7 +15,7 @@
 #
 
 # Adjust the dalvik heap to be appropriate for a tablet.
-$(call inherit-product-if-exists, frameworks/native/build/tablet-10in-xhdpi-2048-dalvik-heap.mk)
+$(call inherit-product-if-exists, frameworks/native/build/tablet-7in-hdpi-1024-dalvik-heap.mk)
 
 PRODUCT_COPY_FILES += $(call add-to-product-copy-files-if-exists,\
 			$(LOCAL_PATH)/fstab.hikey:root/fstab.hikey \


### PR DESCRIPTION
since we have hikey version which only has 1024MB ram

Signed-off-by: Yongqin Liu yongqin.liu@linaro.org
