### PR TITLE
sepolicy/init.te: make init be able to create file under sysfs

### DIFF
--- a/sepolicy/init.te
+++ b/sepolicy/init.te
@@ -10,3 +10,5 @@ allow init self:capability { sys_module sys_pacct };
 allow init bootchart_data_file:file { append };
 
 allow init shell_data_file:lnk_file { getattr };
+
+allow init sysfs:dir write;


### PR DESCRIPTION
Fix following avc warnings:
[   11.633203] type=1400 audit(21.679:4): avc: denied { write } for pid=1 comm="init" name="android0" dev="sysfs" ino=11952 scontext=u:r:init:s0 tcontext=u:object_r:sysfs:s0 tclass=dir permissive=0
[   11.660232] type=1400 audit(21.709:5): avc: denied { write } for pid=1 comm="init" name="android0" dev="sysfs" ino=11952 scontext=u:r:init:s0 tcontext=u:object_r:sysfs:s0 tclass=dir permissive=0
[   11.687414] type=1400 audit(21.739:6): avc: denied { write } for pid=1 comm="init" name="android0" dev="sysfs" ino=11952 scontext=u:r:init:s0 tcontext=u:object_r:sysfs:s0 tclass=dir permissive=0
[   11.714710] type=1400 audit(21.759:7): avc: denied { write } for pid=1 comm="init" name="android0" dev="sysfs" ino=11952 scontext=u:r:init:s0 tcontext=u:object_r:sysfs:s0 tclass=dir permissive=0
[   11.745961] type=1400 audit(21.789:8): avc: denied { write } for pid=1 comm="init" name="android0" dev="sysfs" ino=11952 scontext=u:r:init:s0 tcontext=u:object_r:sysfs:s0 tclass=dir permissive=0

Signed-off-by: Yongqin Liu yongqin.liu@linaro.org
